### PR TITLE
Bundle some defaults into original st2.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## In Development
+
+
+## v0.5.1
+*  Move some of the defaults into original st2.conf
+
+## v0.5.0
+* Add st2packs, - a way to use custom st2 packs as a shareable Docker image via sidecar containers
+
+## v0.4.0
+* Initial public version, referencing StackStorm Enterprise HA as a Helm chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm Enterprise version here to rely on other Docker images tags
 appVersion: 2.9dev
 name: stackstorm-enterprise-ha
-version: 0.5.0
+version: 0.5.1
 description: StackStorm Enterprise K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -14,21 +14,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  # TODO: Bundle Docker-friendly defaults like 'host = 0.0.0.0' in original st2.conf during the Docker container build (?)
   # TODO: Bundle DB/MQ login secrets in dynamic ENV-based st2.secrets.conf, leave custom user-defined settings for st2.user.conf (?)
   # Docker/K8s-based st2 config file used for templating service names and common overrides on top of original st2.conf.
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
   st2.docker.conf: |
     [auth]
-    enable = True
-    host = 0.0.0.0
     api_url = http://{{ .Release.Name }}-st2api-enterprise:9101/
-    [api]
-    host = 0.0.0.0
-    [stream]
-    host = 0.0.0.0
-    [rbac]
-    enable = True
     [coordination]
     url = etcd://{{ .Release.Name }}-etcd:2379
     [messaging]


### PR DESCRIPTION

Bundle some Docker-friendly defaults like `host = 0.0.0.0` into original `st2.conf`.

